### PR TITLE
Fix git build by adapting to new location of upstream .desktop file

### DIFF
--- a/net.minetest.app.git.json
+++ b/net.minetest.app.git.json
@@ -5,9 +5,10 @@
 	"runtime-version": "1.4",
 	"sdk": "org.freedesktop.Sdk",
 	"command": "minetest",
-	"rename-desktop-file": "minetest.desktop",
 	"desktop-file-name-suffix": " (git)",
+	"rename-desktop-file": "net.minetest.minetest.desktop",
 	"rename-icon": "minetest",
+	"rename-appdata": "net.minetest.minetest.appdata.xml",
 	"finish-args": [
 		"--socket=x11",
 		"--socket=pulseaudio",


### PR DESCRIPTION
Upstream renamed it's desktop file, breaking our git build. This PR fixes that.